### PR TITLE
Add Supabase auth, cloud sync, and share workout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+EXPO_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -19,7 +19,7 @@ jobs:
         run: npm install
 
       - name: Install EAS CLI
-        run: npm install -g eas-cli
+        run: npm install -g eas-cli@latest
 
       - name: Build and Submit to TestFlight
         run: eas build --platform ios --profile production --auto-submit --non-interactive

--- a/.gitignore
+++ b/.gitignore
@@ -79,4 +79,5 @@ yarn-error.*
 # typescript
 *.tsbuildinfo
 
-# @end expo-cli
+# @end expo-cli.env
+.env

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Muscleminded",
     "slug": "gym-track",
-    "version": "4.0.5",
+    "version": "4.0.6",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -32,7 +32,11 @@
       "favicon": "./assets/favicon.png",
       "bundler": "metro"
     },
-    "plugins": ["expo-router", "expo-secure-store"],
+    "plugins": [
+      "expo-router",
+      "expo-secure-store",
+      "expo-sqlite"
+    ],
     "experiments": {
       "typedRoutes": true
     },

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -9,17 +9,13 @@ export default function TabLayout() {
   return (
     <Tabs
       screenOptions={{
+        headerShown: false,
         tabBarActiveTintColor: "#10b981",
         tabBarInactiveTintColor: isDark ? "#9ca3af" : "#6b7280",
         tabBarStyle: {
           backgroundColor: isDark ? "#1e293b" : "#ffffff",
           borderTopColor: isDark ? "#334155" : "#e5e7eb",
         },
-        headerStyle: {
-          backgroundColor: isDark ? "#1e293b" : "#ffffff",
-        },
-        headerTintColor: isDark ? "#f9fafb" : "#111827",
-        headerShadowVisible: false,
       }}
     >
       <Tabs.Screen
@@ -35,7 +31,6 @@ export default function TabLayout() {
         name="workout"
         options={{
           title: "Workout",
-          headerShown: false,
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="barbell" size={size} color={color} />
           ),

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -19,6 +19,8 @@ import {
 } from "@/lib/db";
 import type { Workout } from "@/types";
 import CopyWorkoutModal from "@/components/CopyWorkoutModal";
+import { shareWorkout } from "@/lib/share";
+import { useSettingsStore } from "@/stores/settings-store";
 
 interface WorkoutWithStats extends Workout {
   exerciseCount: number;
@@ -32,6 +34,7 @@ interface SelectedWorkout {
 
 export default function HistoryScreen() {
   const router = useRouter();
+  const { unitPreference } = useSettingsStore();
   const [workouts, setWorkouts] = useState<WorkoutWithStats[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -302,6 +305,28 @@ export default function HistoryScreen() {
                 </Text>
               </View>
               <Ionicons name="chevron-forward" size={18} color="#9ca3af" />
+            </Pressable>
+
+            {/* Share option */}
+            <Pressable
+              onPress={() => {
+                const id = actionSheetWorkout?.id;
+                setActionSheetWorkout(null);
+                if (id) shareWorkout(id, unitPreference);
+              }}
+              className="flex-row items-center px-6 py-4 active:bg-slate-100 dark:active:bg-slate-700"
+            >
+              <View className="w-10 h-10 rounded-full bg-blue-100 dark:bg-blue-900/40 items-center justify-center mr-4">
+                <Ionicons name="share-outline" size={20} color="#3b82f6" />
+              </View>
+              <View className="flex-1">
+                <Text className="text-base font-medium text-slate-900 dark:text-white">
+                  Share Workout
+                </Text>
+                <Text className="text-sm text-slate-500 dark:text-slate-400">
+                  Share a summary via messages, notes, etc.
+                </Text>
+              </View>
             </Pressable>
           </View>
         </View>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -40,7 +40,9 @@ export default function HomeScreen() {
   const [workoutsThisWeek, setWorkoutsThisWeek] = useState(0);
   const [totalVolume, setTotalVolume] = useState(0);
   const [recentWorkouts, setRecentWorkouts] = useState<Workout[]>([]);
-  const [muscleGroups, setMuscleGroups] = useState<{ muscle: string; count: number }[]>([]);
+  const [muscleGroups, setMuscleGroups] = useState<
+    { muscle: string; count: number }[]
+  >([]);
   const [refreshing, setRefreshing] = useState(false);
   const [initialized, setInitialized] = useState(false);
 
@@ -151,7 +153,9 @@ export default function HomeScreen() {
               <Text className="font-medium text-slate-900 dark:text-white text-sm">
                 {activeSplit.name}
                 <Text className="text-slate-500 dark:text-slate-400 font-normal">
-                  {" "}· Day {activeSplit.currentDayIndex + 1}/{activeSplit.days.length}
+                  {" "}
+                  · Day {activeSplit.currentDayIndex + 1}/
+                  {activeSplit.days.length}
                 </Text>
               </Text>
             </View>
@@ -167,17 +171,27 @@ export default function HomeScreen() {
         {/* Stats row */}
         <View className="flex-row gap-2 mb-3">
           <View className="flex-1 bg-slate-100 dark:bg-slate-800 rounded-xl px-3 py-2.5">
-            <Text className="text-slate-500 dark:text-slate-400 text-xs">This Week</Text>
+            <Text className="text-slate-500 dark:text-slate-400 text-xs">
+              This Week
+            </Text>
             <Text className="text-xl font-bold text-slate-900 dark:text-white leading-tight">
               {workoutsThisWeek}
-              <Text className="text-sm font-normal text-slate-500 dark:text-slate-400"> workouts</Text>
+              <Text className="text-sm font-normal text-slate-500 dark:text-slate-400">
+                {" "}
+                workouts
+              </Text>
             </Text>
           </View>
           <View className="flex-1 bg-slate-100 dark:bg-slate-800 rounded-xl px-3 py-2.5">
-            <Text className="text-slate-500 dark:text-slate-400 text-xs">Volume</Text>
+            <Text className="text-slate-500 dark:text-slate-400 text-xs">
+              Volume
+            </Text>
             <Text className="text-xl font-bold text-slate-900 dark:text-white leading-tight">
               {formatVolume(totalVolume)}
-              <Text className="text-sm font-normal text-slate-500 dark:text-slate-400"> kg</Text>
+              <Text className="text-sm font-normal text-slate-500 dark:text-slate-400">
+                {" "}
+                kg
+              </Text>
             </Text>
           </View>
         </View>
@@ -198,7 +212,9 @@ export default function HomeScreen() {
                     {MUSCLE_LABELS[muscle] ?? muscle}
                   </Text>
                   {count > 1 && (
-                    <Text className="text-primary-500/70 text-xs">×{count}</Text>
+                    <Text className="text-primary-500/70 text-xs">
+                      ×{count}
+                    </Text>
                   )}
                 </View>
               ))}
@@ -240,8 +256,13 @@ export default function HomeScreen() {
             <Text className="text-base font-semibold text-slate-900 dark:text-white">
               Recent Workouts
             </Text>
-            <Pressable onPress={() => router.push("/(tabs)/history")} className="active:opacity-70">
-              <Text className="text-primary-500 text-xs font-medium">See all</Text>
+            <Pressable
+              onPress={() => router.push("/(tabs)/history")}
+              className="active:opacity-70"
+            >
+              <Text className="text-primary-500 text-xs font-medium">
+                See all
+              </Text>
             </Pressable>
           </View>
           {recentWorkouts.length === 0 ? (
@@ -259,7 +280,10 @@ export default function HomeScreen() {
                   className="bg-slate-100 dark:bg-slate-800 rounded-xl px-3 py-2.5 active:bg-slate-200 dark:active:bg-slate-700 flex-row items-center justify-between"
                 >
                   <View className="flex-1 mr-2">
-                    <Text className="font-medium text-slate-900 dark:text-white text-sm" numberOfLines={1}>
+                    <Text
+                      className="font-medium text-slate-900 dark:text-white text-sm"
+                      numberOfLines={1}
+                    >
                       {workout.name || "Workout"}
                     </Text>
                     <Text className="text-xs text-slate-500 dark:text-slate-400">
@@ -290,12 +314,7 @@ export default function HomeScreen() {
                 Exercises
               </Text>
             </Pressable>
-            <Pressable className="flex-1 bg-slate-100 dark:bg-slate-800 rounded-xl py-3 items-center active:bg-slate-200 dark:active:bg-slate-700">
-              <Ionicons name="list" size={20} color="#10b981" />
-              <Text className="text-slate-700 dark:text-slate-300 mt-1 text-xs">
-                Routines
-              </Text>
-            </Pressable>
+
             <Pressable
               onPress={() => router.push("/(tabs)/progress")}
               className="flex-1 bg-slate-100 dark:bg-slate-800 rounded-xl py-3 items-center active:bg-slate-200 dark:active:bg-slate-700"

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,26 +1,89 @@
-import { View, Text, ScrollView, Pressable, Switch, Modal, ActivityIndicator, Alert, TextInput } from "react-native";
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  Switch,
+  Modal,
+  ActivityIndicator,
+  Alert,
+  TextInput,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
+import { useColorScheme } from "nativewind";
+import { useRouter } from "expo-router";
 import { exportWorkouts, shareExportFile, type ExportRange } from "@/lib/export";
 import { getApiKey, setApiKey, clearApiKey } from "@/lib/ai/claude";
+import { useSettingsStore } from "@/stores/settings-store";
+import { useAuthStore } from "@/stores/auth-store";
+import {
+  addBodyMeasurement,
+  getBodyMeasurements,
+  getLatestBodyMeasurement,
+  getLifetimeStats,
+  type LifetimeStats,
+} from "@/lib/db/workouts";
+import {
+  backupAllToCloud,
+  restoreFromCloud,
+  getLastSyncedAt,
+} from "@/lib/sync";
+import type { BodyMeasurement } from "@/types";
 
 export default function ProfileScreen() {
-  const [darkMode, setDarkMode] = useState(false);
-  const [useKg, setUseKg] = useState(true);
-  const [showExportModal, setShowExportModal] = useState(false);
-  const [exporting, setExporting] = useState(false);
+  const router = useRouter();
+  const { colorScheme } = useColorScheme();
+  const {
+    unitPreference, setUnitPreference,
+    themePreference, setThemePreference,
+    displayName, setDisplayName,
+  } = useSettingsStore();
+  const { user, isAuthenticated, signOut } = useAuthStore();
+
+  // API key state
   const [showApiKeyModal, setShowApiKeyModal] = useState(false);
   const [apiKeyInput, setApiKeyInput] = useState("");
   const [hasApiKey, setHasApiKey] = useState(false);
   const [maskedKey, setMaskedKey] = useState("");
 
-  useEffect(() => {
-    loadApiKeyStatus();
-  }, []);
+  // Export state
+  const [showExportModal, setShowExportModal] = useState(false);
+  const [exporting, setExporting] = useState(false);
 
-  const loadApiKeyStatus = async () => {
-    const key = await getApiKey();
+  // Display name editing
+  const [showNameModal, setShowNameModal] = useState(false);
+  const [nameInput, setNameInput] = useState("");
+
+  // Body weight state
+  const [latestWeight, setLatestWeight] = useState<BodyMeasurement | null>(null);
+  const [measurements, setMeasurements] = useState<BodyMeasurement[]>([]);
+  const [showWeightModal, setShowWeightModal] = useState(false);
+  const [showWeightHistory, setShowWeightHistory] = useState(false);
+  const [weightInput, setWeightInput] = useState("");
+  const [weightNotes, setWeightNotes] = useState("");
+
+  // Lifetime stats
+  const [stats, setStats] = useState<LifetimeStats | null>(null);
+
+  // Sync state
+  const [lastSyncedAt, setLastSyncedAt] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [restoring, setRestoring] = useState(false);
+
+  const loadData = useCallback(async () => {
+    const [latest, allMeasurements, lifetimeStats, key, lastSync] = await Promise.all([
+      getLatestBodyMeasurement(),
+      getBodyMeasurements(7),
+      getLifetimeStats(),
+      getApiKey(),
+      getLastSyncedAt(),
+    ]);
+    setLatestWeight(latest);
+    setMeasurements(allMeasurements);
+    setStats(lifetimeStats);
+    setLastSyncedAt(lastSync);
     if (key) {
       setHasApiKey(true);
       setMaskedKey(`sk-...${key.slice(-4)}`);
@@ -28,18 +91,82 @@ export default function ProfileScreen() {
       setHasApiKey(false);
       setMaskedKey("");
     }
-  };
+  }, []);
+
+  useEffect(() => { loadData(); }, [loadData]);
 
   const handleSaveApiKey = async () => {
     const trimmed = apiKeyInput.trim();
-    if (trimmed) {
-      await setApiKey(trimmed);
-    } else {
-      await clearApiKey();
-    }
+    if (trimmed) await setApiKey(trimmed);
+    else await clearApiKey();
     setApiKeyInput("");
     setShowApiKeyModal(false);
-    await loadApiKeyStatus();
+    await loadData();
+  };
+
+  const handleSaveName = () => {
+    setDisplayName(nameInput.trim());
+    setShowNameModal(false);
+  };
+
+  const handleLogWeight = async () => {
+    const val = parseFloat(weightInput);
+    if (isNaN(val) || val <= 0) {
+      Alert.alert("Invalid weight", "Enter a valid weight.");
+      return;
+    }
+    await addBodyMeasurement(val, weightNotes.trim() || undefined);
+    setWeightInput("");
+    setWeightNotes("");
+    setShowWeightModal(false);
+    await loadData();
+  };
+
+  const handleBackup = async () => {
+    if (!user) return;
+    setSyncing(true);
+    try {
+      const { workouts } = await backupAllToCloud(user.id);
+      await loadData();
+      Alert.alert("Backup complete", `${workouts} workout${workouts !== 1 ? "s" : ""} backed up.`);
+    } catch {
+      Alert.alert("Backup failed", "Something went wrong. Try again.");
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const handleRestore = () => {
+    if (!user) return;
+    Alert.alert(
+      "Restore from cloud",
+      "This will merge your cloud data into this device. Local data won't be deleted. Continue?",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Restore",
+          onPress: async () => {
+            setRestoring(true);
+            try {
+              const { workouts } = await restoreFromCloud(user.id);
+              await loadData();
+              Alert.alert("Restore complete", `${workouts} workout${workouts !== 1 ? "s" : ""} restored.`);
+            } catch {
+              Alert.alert("Restore failed", "Something went wrong. Try again.");
+            } finally {
+              setRestoring(false);
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const handleSignOut = () => {
+    Alert.alert("Sign out", "Are you sure?", [
+      { text: "Cancel", style: "cancel" },
+      { text: "Sign out", style: "destructive", onPress: signOut },
+    ]);
   };
 
   const exportRanges: { label: string; value: ExportRange }[] = [
@@ -54,124 +181,247 @@ export default function ProfileScreen() {
     try {
       const { workoutCount, filePath } = await exportWorkouts(range);
       setShowExportModal(false);
-
       if (workoutCount === 0) {
         Alert.alert("No Workouts", "No completed workouts found in this period.");
         return;
       }
-
       Alert.alert(
         "Export Ready",
         `Exported ${workoutCount} workout${workoutCount !== 1 ? "s" : ""} as JSON.`,
         [
           { text: "Cancel", style: "cancel" },
-          {
-            text: "Share",
-            onPress: () => shareExportFile(filePath),
-          },
+          { text: "Share", onPress: () => shareExportFile(filePath) },
         ]
       );
-    } catch (error) {
+    } catch {
       Alert.alert("Export Failed", "Something went wrong while exporting your data.");
     } finally {
       setExporting(false);
     }
   };
 
+  const formatVolume = (vol: number) =>
+    vol >= 1000 ? `${(vol / 1000).toFixed(1)}k` : vol.toFixed(0);
+
+  const formatWeight = (w: number) =>
+    unitPreference === "lbs" ? `${(w * 2.205).toFixed(1)} lbs` : `${w} kg`;
+
+  const formatMuscle = (m: string | null) =>
+    m ? m.charAt(0).toUpperCase() + m.slice(1) : "—";
+
+  const formatDate = (iso: string) =>
+    new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+
+  const formatSyncTime = (iso: string) => {
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" }) +
+      " at " + d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  };
+
   return (
     <SafeAreaView className="flex-1 bg-white dark:bg-slate-900">
       <ScrollView className="flex-1 px-4">
-        {/* Header */}
         <View className="py-6">
-          <Text className="text-2xl font-bold text-slate-900 dark:text-white">
-            Profile
-          </Text>
+          <Text className="text-2xl font-bold text-slate-900 dark:text-white">Profile</Text>
         </View>
 
         {/* User Profile Card */}
-        <View className="bg-slate-100 dark:bg-slate-800 rounded-xl p-4 mb-6">
+        <Pressable
+          onPress={() => { setNameInput(displayName); setShowNameModal(true); }}
+          className="bg-slate-100 dark:bg-slate-800 rounded-xl p-4 mb-4 active:opacity-80"
+        >
           <View className="flex-row items-center">
             <View className="w-16 h-16 bg-primary-500 rounded-full items-center justify-center">
               <Ionicons name="person" size={32} color="white" />
             </View>
             <View className="ml-4 flex-1">
               <Text className="text-lg font-semibold text-slate-900 dark:text-white">
-                Guest User
+                {displayName || "Set your name"}
               </Text>
-              <Text className="text-slate-500 dark:text-slate-400">
-                Sign in to sync your data
-              </Text>
+              {isAuthenticated ? (
+                <Text className="text-slate-500 dark:text-slate-400 text-sm">{user?.email}</Text>
+              ) : (
+                <Text className="text-slate-500 dark:text-slate-400 text-sm">Tap to edit</Text>
+              )}
             </View>
+            <Ionicons name="pencil-outline" size={18} color="#9ca3af" />
           </View>
-          <Pressable className="bg-primary-500 rounded-lg py-3 mt-4 active:bg-primary-600">
+        </Pressable>
+
+        {/* Auth / Cloud Section */}
+        {isAuthenticated ? (
+          <View className="bg-slate-100 dark:bg-slate-800 rounded-xl mb-6">
+            {/* Backup */}
+            <Pressable
+              onPress={handleBackup}
+              disabled={syncing}
+              className="flex-row items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700 active:opacity-70"
+            >
+              <View className="flex-row items-center flex-1">
+                <Ionicons name="cloud-upload" size={22} color="#10b981" />
+                <View className="ml-3">
+                  <Text className="text-slate-900 dark:text-white">Back up now</Text>
+                  {lastSyncedAt && (
+                    <Text className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                      Last: {formatSyncTime(lastSyncedAt)}
+                    </Text>
+                  )}
+                </View>
+              </View>
+              {syncing
+                ? <ActivityIndicator size="small" color="#10b981" />
+                : <Ionicons name="chevron-forward" size={18} color="#9ca3af" />
+              }
+            </Pressable>
+
+            {/* Restore */}
+            <Pressable
+              onPress={handleRestore}
+              disabled={restoring}
+              className="flex-row items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700 active:opacity-70"
+            >
+              <View className="flex-row items-center">
+                <Ionicons name="cloud-download" size={22} color="#10b981" />
+                <Text className="ml-3 text-slate-900 dark:text-white">Restore from cloud</Text>
+              </View>
+              {restoring
+                ? <ActivityIndicator size="small" color="#10b981" />
+                : <Ionicons name="chevron-forward" size={18} color="#9ca3af" />
+              }
+            </Pressable>
+
+            {/* Sign out */}
+            <Pressable
+              onPress={handleSignOut}
+              className="flex-row items-center p-4 active:opacity-70"
+            >
+              <Ionicons name="log-out-outline" size={22} color="#ef4444" />
+              <Text className="ml-3 text-red-500 font-medium">Sign out</Text>
+            </Pressable>
+          </View>
+        ) : (
+          <Pressable
+            onPress={() => router.push("/sign-in")}
+            className="bg-primary-500 rounded-xl py-3 mb-6 active:bg-primary-600"
+          >
             <Text className="text-white font-semibold text-center">
-              Sign In
+              Sign in to back up your data
             </Text>
           </Pressable>
+        )}
+
+        {/* Lifetime Stats */}
+        {stats && (
+          <>
+            <Text className="text-lg font-semibold text-slate-900 dark:text-white mb-3">All Time</Text>
+            <View className="flex-row gap-3 mb-4">
+              <View className="flex-1 bg-slate-100 dark:bg-slate-800 rounded-xl p-4 items-center">
+                <Text className="text-2xl font-bold text-primary-500">{stats.total_workouts}</Text>
+                <Text className="text-xs text-slate-500 dark:text-slate-400 mt-1">Workouts</Text>
+              </View>
+              <View className="flex-1 bg-slate-100 dark:bg-slate-800 rounded-xl p-4 items-center">
+                <Text className="text-2xl font-bold text-primary-500">{formatVolume(stats.total_volume)}</Text>
+                <Text className="text-xs text-slate-500 dark:text-slate-400 mt-1">Volume ({unitPreference})</Text>
+              </View>
+              <View className="flex-1 bg-slate-100 dark:bg-slate-800 rounded-xl p-4 items-center">
+                <Text className="text-2xl font-bold text-primary-500">{stats.total_prs}</Text>
+                <Text className="text-xs text-slate-500 dark:text-slate-400 mt-1">PRs</Text>
+              </View>
+            </View>
+            {stats.top_muscle && (
+              <View className="bg-slate-100 dark:bg-slate-800 rounded-xl p-4 mb-6 flex-row items-center">
+                <Ionicons name="trophy" size={20} color="#10b981" />
+                <Text className="ml-3 text-slate-900 dark:text-white">
+                  Favourite muscle:{" "}
+                  <Text className="font-semibold text-primary-500">{formatMuscle(stats.top_muscle)}</Text>
+                </Text>
+              </View>
+            )}
+          </>
+        )}
+
+        {/* Body Weight */}
+        <Text className="text-lg font-semibold text-slate-900 dark:text-white mb-3">Body Weight</Text>
+        <View className="bg-slate-100 dark:bg-slate-800 rounded-xl mb-6">
+          <View className="flex-row items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700">
+            <View>
+              <Text className="text-slate-900 dark:text-white font-medium">
+                {latestWeight ? formatWeight(latestWeight.weight!) : "Not logged"}
+              </Text>
+              {latestWeight && (
+                <Text className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                  {formatDate(latestWeight.measured_at)}
+                </Text>
+              )}
+            </View>
+            <Pressable
+              onPress={() => setShowWeightModal(true)}
+              className="bg-primary-500 rounded-lg px-3 py-2 active:bg-primary-600"
+            >
+              <Text className="text-white text-sm font-semibold">Log</Text>
+            </Pressable>
+          </View>
+
+          {measurements.length > 0 && (
+            <Pressable
+              onPress={() => setShowWeightHistory(!showWeightHistory)}
+              className="flex-row items-center justify-between p-4"
+            >
+              <Text className="text-slate-500 dark:text-slate-400 text-sm">
+                {showWeightHistory ? "Hide" : "Show"} history ({measurements.length})
+              </Text>
+              <Ionicons name={showWeightHistory ? "chevron-up" : "chevron-down"} size={16} color="#9ca3af" />
+            </Pressable>
+          )}
+
+          {showWeightHistory && measurements.map((m) => (
+            <View key={m.id} className="flex-row items-center justify-between px-4 py-3 border-t border-slate-200 dark:border-slate-700">
+              <Text className="text-slate-900 dark:text-white text-sm">{formatWeight(m.weight!)}</Text>
+              <View className="items-end">
+                <Text className="text-xs text-slate-500 dark:text-slate-400">{formatDate(m.measured_at)}</Text>
+                {m.notes && <Text className="text-xs text-slate-400 dark:text-slate-500">{m.notes}</Text>}
+              </View>
+            </View>
+          ))}
         </View>
 
-        {/* Settings Section */}
-        <Text className="text-lg font-semibold text-slate-900 dark:text-white mb-3">
-          Settings
-        </Text>
-
+        {/* Settings */}
+        <Text className="text-lg font-semibold text-slate-900 dark:text-white mb-3">Settings</Text>
         <View className="bg-slate-100 dark:bg-slate-800 rounded-xl mb-6">
-          {/* Units */}
           <View className="flex-row items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700">
             <View className="flex-row items-center">
               <Ionicons name="scale" size={24} color="#10b981" />
-              <Text className="ml-3 text-slate-900 dark:text-white">
-                Weight Unit
-              </Text>
+              <Text className="ml-3 text-slate-900 dark:text-white">Weight Unit</Text>
             </View>
             <View className="flex-row items-center">
-              <Text className="text-slate-500 dark:text-slate-400 mr-2">
-                {useKg ? "kg" : "lbs"}
-              </Text>
+              <Text className="text-slate-500 dark:text-slate-400 mr-2">{unitPreference}</Text>
               <Switch
-                value={useKg}
-                onValueChange={setUseKg}
+                value={unitPreference === "kg"}
+                onValueChange={(val) => setUnitPreference(val ? "kg" : "lbs")}
                 trackColor={{ false: "#64748b", true: "#10b981" }}
               />
             </View>
           </View>
 
-          {/* Theme */}
           <View className="flex-row items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700">
             <View className="flex-row items-center">
               <Ionicons name="moon" size={24} color="#10b981" />
-              <Text className="ml-3 text-slate-900 dark:text-white">
-                Dark Mode
-              </Text>
+              <Text className="ml-3 text-slate-900 dark:text-white">Dark Mode</Text>
             </View>
             <Switch
-              value={darkMode}
-              onValueChange={setDarkMode}
+              value={themePreference === "dark"}
+              onValueChange={(val) => setThemePreference(val ? "dark" : "light")}
               trackColor={{ false: "#64748b", true: "#10b981" }}
             />
           </View>
 
-          {/* Notifications */}
-          <Pressable className="flex-row items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700">
-            <View className="flex-row items-center">
-              <Ionicons name="notifications" size={24} color="#10b981" />
-              <Text className="ml-3 text-slate-900 dark:text-white">
-                Notifications
-              </Text>
-            </View>
-            <Ionicons name="chevron-forward" size={20} color="#9ca3af" />
-          </Pressable>
-
-          {/* Claude API Key */}
           <Pressable
             onPress={() => setShowApiKeyModal(true)}
             className="flex-row items-center justify-between p-4"
           >
             <View className="flex-row items-center">
               <Ionicons name="key" size={24} color="#10b981" />
-              <Text className="ml-3 text-slate-900 dark:text-white">
-                Claude API Key
-              </Text>
+              <Text className="ml-3 text-slate-900 dark:text-white">Claude API Key</Text>
             </View>
             <View className="flex-row items-center">
               <Text className="text-slate-500 dark:text-slate-400 mr-2">
@@ -182,76 +432,103 @@ export default function ProfileScreen() {
           </Pressable>
         </View>
 
-        {/* Data Section */}
-        <Text className="text-lg font-semibold text-slate-900 dark:text-white mb-3">
-          Data
-        </Text>
-
+        {/* Data */}
+        <Text className="text-lg font-semibold text-slate-900 dark:text-white mb-3">Data</Text>
         <View className="bg-slate-100 dark:bg-slate-800 rounded-xl mb-6">
-          {/* Export */}
           <Pressable
             onPress={() => setShowExportModal(true)}
-            className="flex-row items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700"
+            className="flex-row items-center justify-between p-4"
           >
             <View className="flex-row items-center">
               <Ionicons name="download" size={24} color="#10b981" />
-              <Text className="ml-3 text-slate-900 dark:text-white">
-                Export Workouts
-              </Text>
+              <Text className="ml-3 text-slate-900 dark:text-white">Export Workouts</Text>
             </View>
             <Ionicons name="chevron-forward" size={20} color="#9ca3af" />
           </Pressable>
-
-          {/* Sync Status */}
-          <View className="flex-row items-center justify-between p-4">
-            <View className="flex-row items-center">
-              <Ionicons name="cloud" size={24} color="#10b981" />
-              <Text className="ml-3 text-slate-900 dark:text-white">
-                Sync Status
-              </Text>
-            </View>
-            <Text className="text-slate-500 dark:text-slate-400">
-              Not synced
-            </Text>
-          </View>
         </View>
 
-        {/* App Info */}
         <View className="items-center py-6">
-          <Text className="text-slate-400 dark:text-slate-500">
-            GymTrack v1.0.0
-          </Text>
+          <Text className="text-slate-400 dark:text-slate-500">GymTrack v4.0.5</Text>
         </View>
       </ScrollView>
 
-      {/* Export Modal */}
-      <Modal
-        visible={showExportModal}
-        transparent
-        animationType="slide"
-        onRequestClose={() => setShowExportModal(false)}
-      >
+      {/* Edit Name Modal */}
+      <Modal visible={showNameModal} transparent animationType="slide" onRequestClose={() => setShowNameModal(false)}>
         <View className="flex-1 justify-end bg-black/50">
           <View className="bg-white dark:bg-slate-800 rounded-t-2xl p-6">
             <View className="flex-row items-center justify-between mb-4">
-              <Text className="text-xl font-bold text-slate-900 dark:text-white">
-                Export Workouts
-              </Text>
+              <Text className="text-xl font-bold text-slate-900 dark:text-white">Your Name</Text>
+              <Pressable onPress={() => setShowNameModal(false)}>
+                <Ionicons name="close" size={24} color="#9ca3af" />
+              </Pressable>
+            </View>
+            <TextInput
+              value={nameInput}
+              onChangeText={setNameInput}
+              placeholder="Enter your name"
+              placeholderTextColor="#9ca3af"
+              autoFocus
+              className="bg-slate-100 dark:bg-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white mb-4"
+            />
+            <Pressable onPress={handleSaveName} className="bg-primary-500 rounded-xl py-3 active:bg-primary-600">
+              <Text className="text-white font-semibold text-center">Save</Text>
+            </Pressable>
+            <View className="h-8" />
+          </View>
+        </View>
+      </Modal>
+
+      {/* Log Weight Modal */}
+      <Modal visible={showWeightModal} transparent animationType="slide" onRequestClose={() => setShowWeightModal(false)}>
+        <View className="flex-1 justify-end bg-black/50">
+          <View className="bg-white dark:bg-slate-800 rounded-t-2xl p-6">
+            <View className="flex-row items-center justify-between mb-4">
+              <Text className="text-xl font-bold text-slate-900 dark:text-white">Log Weight</Text>
+              <Pressable onPress={() => setShowWeightModal(false)}>
+                <Ionicons name="close" size={24} color="#9ca3af" />
+              </Pressable>
+            </View>
+            <TextInput
+              value={weightInput}
+              onChangeText={setWeightInput}
+              placeholder={`Weight in ${unitPreference}`}
+              placeholderTextColor="#9ca3af"
+              keyboardType="decimal-pad"
+              autoFocus
+              className="bg-slate-100 dark:bg-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white mb-3"
+            />
+            <TextInput
+              value={weightNotes}
+              onChangeText={setWeightNotes}
+              placeholder="Notes (optional)"
+              placeholderTextColor="#9ca3af"
+              className="bg-slate-100 dark:bg-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white mb-4"
+            />
+            <Pressable onPress={handleLogWeight} className="bg-primary-500 rounded-xl py-3 active:bg-primary-600">
+              <Text className="text-white font-semibold text-center">Save</Text>
+            </Pressable>
+            <View className="h-8" />
+          </View>
+        </View>
+      </Modal>
+
+      {/* Export Modal */}
+      <Modal visible={showExportModal} transparent animationType="slide" onRequestClose={() => setShowExportModal(false)}>
+        <View className="flex-1 justify-end bg-black/50">
+          <View className="bg-white dark:bg-slate-800 rounded-t-2xl p-6">
+            <View className="flex-row items-center justify-between mb-4">
+              <Text className="text-xl font-bold text-slate-900 dark:text-white">Export Workouts</Text>
               <Pressable onPress={() => setShowExportModal(false)}>
                 <Ionicons name="close" size={24} color="#9ca3af" />
               </Pressable>
             </View>
-
             <Text className="text-slate-500 dark:text-slate-400 mb-4">
-              Export your workout history as JSON for analysis. Choose a time range:
+              Export your workout history as JSON. Choose a time range:
             </Text>
-
             {exporting ? (
               <View className="items-center py-8">
                 <ActivityIndicator size="large" color="#10b981" />
-                <Text className="text-slate-500 dark:text-slate-400 mt-3">
-                  Preparing export...
-                </Text>
+                <Text className="text-slate-500 dark:text-slate-400 mt-3">Preparing export...</Text>
               </View>
             ) : (
               <View className="gap-3">
@@ -261,41 +538,30 @@ export default function ProfileScreen() {
                     onPress={() => handleExport(range.value)}
                     className="bg-slate-100 dark:bg-slate-700 rounded-xl p-4 flex-row items-center justify-between active:bg-slate-200 dark:active:bg-slate-600"
                   >
-                    <Text className="text-slate-900 dark:text-white font-medium">
-                      {range.label}
-                    </Text>
+                    <Text className="text-slate-900 dark:text-white font-medium">{range.label}</Text>
                     <Ionicons name="download-outline" size={20} color="#10b981" />
                   </Pressable>
                 ))}
               </View>
             )}
-
             <View className="h-8" />
           </View>
         </View>
       </Modal>
+
       {/* API Key Modal */}
-      <Modal
-        visible={showApiKeyModal}
-        transparent
-        animationType="slide"
-        onRequestClose={() => setShowApiKeyModal(false)}
-      >
+      <Modal visible={showApiKeyModal} transparent animationType="slide" onRequestClose={() => setShowApiKeyModal(false)}>
         <View className="flex-1 justify-end bg-black/50">
           <View className="bg-white dark:bg-slate-800 rounded-t-2xl p-6">
             <View className="flex-row items-center justify-between mb-4">
-              <Text className="text-xl font-bold text-slate-900 dark:text-white">
-                Claude API Key
-              </Text>
+              <Text className="text-xl font-bold text-slate-900 dark:text-white">Claude API Key</Text>
               <Pressable onPress={() => setShowApiKeyModal(false)}>
                 <Ionicons name="close" size={24} color="#9ca3af" />
               </Pressable>
             </View>
-
             <Text className="text-slate-500 dark:text-slate-400 mb-4">
-              Enter your Anthropic API key to enable AI workout suggestions. Your key is stored locally on this device.
+              Enter your Anthropic API key to enable AI workout suggestions. Stored locally on this device.
             </Text>
-
             <TextInput
               value={apiKeyInput}
               onChangeText={setApiKeyInput}
@@ -306,18 +572,11 @@ export default function ProfileScreen() {
               secureTextEntry
               className="bg-slate-100 dark:bg-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white mb-4"
             />
-
-            <View className="gap-3">
-              <Pressable
-                onPress={handleSaveApiKey}
-                className="bg-primary-500 rounded-xl py-3 active:bg-primary-600"
-              >
-                <Text className="text-white font-semibold text-center">
-                  {apiKeyInput.trim() ? "Save Key" : hasApiKey ? "Remove Key" : "Cancel"}
-                </Text>
-              </Pressable>
-            </View>
-
+            <Pressable onPress={handleSaveApiKey} className="bg-primary-500 rounded-xl py-3 active:bg-primary-600">
+              <Text className="text-white font-semibold text-center">
+                {apiKeyInput.trim() ? "Save Key" : hasApiKey ? "Remove Key" : "Cancel"}
+              </Text>
+            </Pressable>
             <View className="h-8" />
           </View>
         </View>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,51 @@
 import "../global.css";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { useColorScheme } from "react-native";
+import { useColorScheme } from "nativewind";
+import { useEffect } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { useSettingsStore } from "@/stores/settings-store";
+import { useAuthStore } from "@/stores/auth-store";
+import { supabase } from "@/lib/supabase";
 
 export default function RootLayout() {
-  const colorScheme = useColorScheme();
+  const { colorScheme, setColorScheme } = useColorScheme();
+  const themePreference = useSettingsStore((s) => s.themePreference);
+  const { setUser, setLoading } = useAuthStore();
+
+  useEffect(() => {
+    setColorScheme(themePreference);
+  }, [themePreference]);
+
+  useEffect(() => {
+    // Restore session on launch
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.user) {
+        setUser({
+          id: session.user.id,
+          email: session.user.email ?? "",
+          displayName: null,
+        });
+      } else {
+        setLoading(false);
+      }
+    });
+
+    // Listen for auth state changes
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        setUser({
+          id: session.user.id,
+          email: session.user.email ?? "",
+          displayName: null,
+        });
+      } else {
+        setUser(null);
+      }
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
@@ -18,12 +58,11 @@ export default function RootLayout() {
         }}
       >
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="sign-in" options={{ headerShown: false }} />
+        <Stack.Screen name="sign-up" options={{ headerShown: false }} />
         <Stack.Screen
           name="suggest-workout"
-          options={{
-            headerShown: false,
-            presentation: "modal",
-          }}
+          options={{ headerShown: false, presentation: "modal" }}
         />
       </Stack>
       <StatusBar style={colorScheme === "dark" ? "light" : "dark"} />

--- a/app/sign-in.tsx
+++ b/app/sign-in.tsx
@@ -1,0 +1,89 @@
+import { View, Text, TextInput, Pressable, ActivityIndicator, KeyboardAvoidingView, Platform, Alert } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useRouter } from "expo-router";
+import { useState } from "react";
+import { useAuthStore } from "@/stores/auth-store";
+
+export default function SignInScreen() {
+  const router = useRouter();
+  const { signIn } = useAuthStore();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSignIn = async () => {
+    if (!email.trim() || !password) return;
+    setLoading(true);
+    const error = await signIn(email.trim().toLowerCase(), password);
+    setLoading(false);
+    if (error) {
+      Alert.alert("Sign in failed", error);
+    } else {
+      router.replace("/(tabs)/profile");
+    }
+  };
+
+  return (
+    <SafeAreaView className="flex-1 bg-white dark:bg-slate-900">
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        className="flex-1"
+      >
+        <View className="flex-1 px-6 justify-center">
+          <View className="mb-10">
+            <Text className="text-3xl font-bold text-slate-900 dark:text-white mb-2">
+              Welcome back
+            </Text>
+            <Text className="text-slate-500 dark:text-slate-400">
+              Sign in to sync your workouts
+            </Text>
+          </View>
+
+          <View className="gap-4 mb-6">
+            <TextInput
+              value={email}
+              onChangeText={setEmail}
+              placeholder="Email"
+              placeholderTextColor="#9ca3af"
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              className="bg-slate-100 dark:bg-slate-800 rounded-xl px-4 py-4 text-slate-900 dark:text-white"
+            />
+            <TextInput
+              value={password}
+              onChangeText={setPassword}
+              placeholder="Password"
+              placeholderTextColor="#9ca3af"
+              secureTextEntry
+              className="bg-slate-100 dark:bg-slate-800 rounded-xl px-4 py-4 text-slate-900 dark:text-white"
+            />
+          </View>
+
+          <Pressable
+            onPress={handleSignIn}
+            disabled={loading || !email.trim() || !password}
+            className="bg-primary-500 rounded-xl py-4 items-center active:bg-primary-600 disabled:opacity-50"
+          >
+            {loading ? (
+              <ActivityIndicator color="white" />
+            ) : (
+              <Text className="text-white font-semibold text-base">Sign In</Text>
+            )}
+          </Pressable>
+
+          <Pressable onPress={() => router.replace("/sign-up")} className="mt-6 items-center">
+            <Text className="text-slate-500 dark:text-slate-400">
+              No account?{" "}
+              <Text className="text-primary-500 font-semibold">Sign up</Text>
+            </Text>
+          </Pressable>
+
+          <Pressable onPress={() => router.back()} className="mt-4 items-center">
+            <Text className="text-slate-400 dark:text-slate-500">Continue without signing in</Text>
+          </Pressable>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}

--- a/app/sign-up.tsx
+++ b/app/sign-up.tsx
@@ -1,0 +1,93 @@
+import { View, Text, TextInput, Pressable, ActivityIndicator, KeyboardAvoidingView, Platform, Alert } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useRouter } from "expo-router";
+import { useState } from "react";
+import { useAuthStore } from "@/stores/auth-store";
+
+export default function SignUpScreen() {
+  const router = useRouter();
+  const { signUp } = useAuthStore();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSignUp = async () => {
+    if (!email.trim() || !password) return;
+    if (password.length < 6) {
+      Alert.alert("Weak password", "Password must be at least 6 characters.");
+      return;
+    }
+    setLoading(true);
+    const error = await signUp(email.trim().toLowerCase(), password);
+    setLoading(false);
+    if (error) {
+      Alert.alert("Sign up failed", error);
+    } else {
+      Alert.alert(
+        "Check your email",
+        "We sent a confirmation link. Click it to activate your account.",
+        [{ text: "OK", onPress: () => router.replace("/sign-in") }]
+      );
+    }
+  };
+
+  return (
+    <SafeAreaView className="flex-1 bg-white dark:bg-slate-900">
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        className="flex-1"
+      >
+        <View className="flex-1 px-6 justify-center">
+          <View className="mb-10">
+            <Text className="text-3xl font-bold text-slate-900 dark:text-white mb-2">
+              Create account
+            </Text>
+            <Text className="text-slate-500 dark:text-slate-400">
+              Back up and sync your workouts across devices
+            </Text>
+          </View>
+
+          <View className="gap-4 mb-6">
+            <TextInput
+              value={email}
+              onChangeText={setEmail}
+              placeholder="Email"
+              placeholderTextColor="#9ca3af"
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              className="bg-slate-100 dark:bg-slate-800 rounded-xl px-4 py-4 text-slate-900 dark:text-white"
+            />
+            <TextInput
+              value={password}
+              onChangeText={setPassword}
+              placeholder="Password (min 6 characters)"
+              placeholderTextColor="#9ca3af"
+              secureTextEntry
+              className="bg-slate-100 dark:bg-slate-800 rounded-xl px-4 py-4 text-slate-900 dark:text-white"
+            />
+          </View>
+
+          <Pressable
+            onPress={handleSignUp}
+            disabled={loading || !email.trim() || !password}
+            className="bg-primary-500 rounded-xl py-4 items-center active:bg-primary-600 disabled:opacity-50"
+          >
+            {loading ? (
+              <ActivityIndicator color="white" />
+            ) : (
+              <Text className="text-white font-semibold text-base">Create Account</Text>
+            )}
+          </Pressable>
+
+          <Pressable onPress={() => router.replace("/sign-in")} className="mt-6 items-center">
+            <Text className="text-slate-500 dark:text-slate-400">
+              Already have an account?{" "}
+              <Text className="text-primary-500 font-semibold">Sign in</Text>
+            </Text>
+          </Pressable>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}

--- a/lib/db/workouts.ts
+++ b/lib/db/workouts.ts
@@ -1,5 +1,5 @@
 import { getDatabase, generateId } from "./database";
-import type { Workout, WorkoutExercise, WorkoutSet, PersonalRecord, WorkoutExerciseWithDetails, WorkoutWithDetails, Exercise } from "@/types";
+import type { Workout, WorkoutExercise, WorkoutSet, PersonalRecord, WorkoutExerciseWithDetails, WorkoutWithDetails, Exercise, BodyMeasurement } from "@/types";
 
 // Chart / analytics types
 export interface WeeklyVolumePoint {
@@ -701,6 +701,81 @@ export async function getExercisesUsedInRange(
     [startDate, endDate]
   );
   return results;
+}
+
+// Body measurement operations
+export async function addBodyMeasurement(weight: number, notes?: string): Promise<BodyMeasurement> {
+  const db = await getDatabase();
+  const id = generateId();
+  const measuredAt = new Date().toISOString();
+
+  await db.runAsync(
+    "INSERT INTO body_measurements (id, weight, notes, measured_at) VALUES (?, ?, ?, ?)",
+    [id, weight, notes || null, measuredAt]
+  );
+
+  return { id, weight, notes: notes || null, measured_at: measuredAt, created_at: measuredAt };
+}
+
+export async function getBodyMeasurements(limit: number = 20): Promise<BodyMeasurement[]> {
+  const db = await getDatabase();
+  const results = await db.getAllAsync<BodyMeasurement>(
+    "SELECT * FROM body_measurements ORDER BY measured_at DESC LIMIT ?",
+    [limit]
+  );
+  return results;
+}
+
+export async function getLatestBodyMeasurement(): Promise<BodyMeasurement | null> {
+  const db = await getDatabase();
+  const result = await db.getFirstAsync<BodyMeasurement>(
+    "SELECT * FROM body_measurements ORDER BY measured_at DESC LIMIT 1"
+  );
+  return result || null;
+}
+
+export interface LifetimeStats {
+  total_workouts: number;
+  total_volume: number;
+  total_prs: number;
+  top_muscle: string | null;
+}
+
+export async function getLifetimeStats(): Promise<LifetimeStats> {
+  const db = await getDatabase();
+
+  const totals = await db.getFirstAsync<{ total_workouts: number; total_volume: number | null }>(
+    `SELECT
+       COUNT(DISTINCT w.id) as total_workouts,
+       SUM(ws.reps * ws.weight) as total_volume
+     FROM workouts w
+     LEFT JOIN workout_exercises we ON we.workout_id = w.id
+     LEFT JOIN workout_sets ws ON ws.workout_exercise_id = we.id AND ws.is_completed = 1 AND ws.is_warmup = 0
+     WHERE w.completed_at IS NOT NULL`
+  );
+
+  const prCount = await db.getFirstAsync<{ count: number }>(
+    "SELECT COUNT(*) as count FROM personal_records"
+  );
+
+  const topMuscle = await db.getFirstAsync<{ muscle: string }>(
+    `SELECT e.primary_muscle as muscle, COUNT(ws.id) as set_count
+     FROM workout_sets ws
+     JOIN workout_exercises we ON ws.workout_exercise_id = we.id
+     JOIN exercises e ON we.exercise_id = e.id
+     JOIN workouts w ON we.workout_id = w.id
+     WHERE w.completed_at IS NOT NULL AND ws.is_completed = 1 AND ws.is_warmup = 0
+     GROUP BY e.primary_muscle
+     ORDER BY set_count DESC
+     LIMIT 1`
+  );
+
+  return {
+    total_workouts: totals?.total_workouts || 0,
+    total_volume: totals?.total_volume || 0,
+    total_prs: prCount?.count || 0,
+    top_muscle: topMuscle?.muscle || null,
+  };
 }
 
 // Helper functions

--- a/lib/share.ts
+++ b/lib/share.ts
@@ -1,0 +1,49 @@
+import { Share } from "react-native";
+import { format } from "date-fns";
+import { getWorkoutWithDetails } from "@/lib/db/workouts";
+
+function formatDuration(seconds: number | null): string {
+  if (!seconds) return "";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+export async function shareWorkout(workoutId: string, unit: "kg" | "lbs" = "kg"): Promise<void> {
+  const workout = await getWorkoutWithDetails(workoutId);
+  if (!workout) return;
+
+  const date = format(new Date(workout.started_at), "EEE, MMM d");
+  const duration = formatDuration(workout.duration_seconds);
+  const header = `💪 ${workout.name || "Workout"} — ${date}${duration ? ` · ${duration}` : ""}`;
+
+  const exerciseLines: string[] = [];
+  let totalVolume = 0;
+
+  for (const ex of workout.exercises) {
+    const completedSets = ex.sets.filter((s) => s.is_completed && !s.is_warmup);
+    if (!completedSets.length) continue;
+
+    exerciseLines.push(ex.exercise.name);
+    completedSets.forEach((s, i) => {
+      const w = unit === "lbs" && s.weight ? (s.weight * 2.205).toFixed(1) : s.weight;
+      const weightStr = s.weight ? `${w}${unit}` : "BW";
+      exerciseLines.push(`  Set ${i + 1}: ${weightStr} × ${s.reps ?? "—"}`);
+      if (s.weight && s.reps) totalVolume += s.weight * s.reps;
+    });
+    exerciseLines.push("");
+  }
+
+  const volumeStr = totalVolume >= 1000
+    ? `${(totalVolume / 1000).toFixed(1)}k ${unit}`
+    : `${Math.round(totalVolume)} ${unit}`;
+
+  const footer = [
+    totalVolume > 0 && `Total volume: ${volumeStr}`,
+    workout.exercises.length > 0 && `${workout.exercises.length} exercise${workout.exercises.length !== 1 ? "s" : ""}`,
+  ].filter(Boolean).join(" | ");
+
+  const message = [header, "", ...exerciseLines, footer].join("\n").trim();
+
+  await Share.share({ message });
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,4 +1,3 @@
-import "react-native-url-polyfill/dist/setup";
 import { createClient } from "@supabase/supabase-js";
 import * as SecureStore from "expo-secure-store";
 

--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -1,0 +1,159 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { supabase } from "@/lib/supabase";
+import { getDatabase, generateId } from "@/lib/db/database";
+import {
+  getAllWorkouts,
+  getWorkoutWithDetails,
+  getBodyMeasurements,
+} from "@/lib/db/workouts";
+
+const LAST_SYNCED_KEY = "gym-track-last-synced";
+
+export async function getLastSyncedAt(): Promise<string | null> {
+  return AsyncStorage.getItem(LAST_SYNCED_KEY);
+}
+
+async function setLastSyncedAt(): Promise<void> {
+  await AsyncStorage.setItem(LAST_SYNCED_KEY, new Date().toISOString());
+}
+
+// Push a single completed workout (+ its exercises, sets) to Supabase
+export async function syncWorkoutToCloud(workoutId: string, userId: string): Promise<void> {
+  const workout = await getWorkoutWithDetails(workoutId);
+  if (!workout || !workout.completed_at) return;
+
+  // Upsert workout
+  await supabase.from("gt_workouts").upsert({
+    id: workout.id,
+    user_id: userId,
+    name: workout.name,
+    notes: workout.notes,
+    started_at: workout.started_at,
+    completed_at: workout.completed_at,
+    duration_seconds: workout.duration_seconds,
+    created_at: workout.created_at,
+  });
+
+  for (const we of workout.exercises) {
+    await supabase.from("gt_workout_exercises").upsert({
+      id: we.id,
+      user_id: userId,
+      workout_id: workout.id,
+      exercise_id: we.exercise_id,
+      order_index: we.order_index,
+      notes: we.notes,
+      created_at: we.created_at,
+    });
+
+    const completedSets = we.sets.filter((s) => s.is_completed);
+    for (const s of completedSets) {
+      await supabase.from("gt_workout_sets").upsert({
+        id: s.id,
+        user_id: userId,
+        workout_exercise_id: we.id,
+        set_number: s.set_number,
+        reps: s.reps,
+        weight: s.weight,
+        is_warmup: s.is_warmup,
+        is_completed: s.is_completed,
+        created_at: s.created_at,
+      });
+    }
+  }
+
+  await setLastSyncedAt();
+}
+
+// Push all local data to Supabase
+export async function backupAllToCloud(userId: string): Promise<{ workouts: number }> {
+  const workouts = await getAllWorkouts();
+  let count = 0;
+
+  for (const workout of workouts) {
+    await syncWorkoutToCloud(workout.id, userId);
+    count++;
+  }
+
+  // Sync body measurements
+  const measurements = await getBodyMeasurements(1000);
+  for (const m of measurements) {
+    await supabase.from("gt_body_measurements").upsert({
+      id: m.id,
+      user_id: userId,
+      weight: m.weight,
+      notes: m.notes,
+      measured_at: m.measured_at,
+      created_at: m.created_at,
+    });
+  }
+
+  await setLastSyncedAt();
+  return { workouts: count };
+}
+
+// Pull all cloud data into local SQLite (INSERT OR IGNORE — never overwrites local)
+export async function restoreFromCloud(userId: string): Promise<{ workouts: number }> {
+  const db = await getDatabase();
+
+  // Fetch all user's workouts from Supabase
+  const { data: cloudWorkouts } = await supabase
+    .from("gt_workouts")
+    .select("*")
+    .eq("user_id", userId);
+
+  if (!cloudWorkouts?.length) return { workouts: 0 };
+
+  for (const w of cloudWorkouts) {
+    await db.runAsync(
+      `INSERT OR IGNORE INTO workouts (id, name, notes, started_at, completed_at, duration_seconds, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [w.id, w.name, w.notes, w.started_at, w.completed_at, w.duration_seconds, w.created_at]
+    );
+
+    // Fetch exercises for this workout
+    const { data: cloudExercises } = await supabase
+      .from("gt_workout_exercises")
+      .select("*")
+      .eq("workout_id", w.id)
+      .eq("user_id", userId);
+
+    for (const we of cloudExercises ?? []) {
+      await db.runAsync(
+        `INSERT OR IGNORE INTO workout_exercises (id, workout_id, exercise_id, order_index, notes, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        [we.id, we.workout_id, we.exercise_id, we.order_index, we.notes, we.created_at]
+      );
+
+      // Fetch sets
+      const { data: cloudSets } = await supabase
+        .from("gt_workout_sets")
+        .select("*")
+        .eq("workout_exercise_id", we.id)
+        .eq("user_id", userId);
+
+      for (const s of cloudSets ?? []) {
+        await db.runAsync(
+          `INSERT OR IGNORE INTO workout_sets (id, workout_exercise_id, set_number, reps, weight, is_warmup, is_completed, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          [s.id, s.workout_exercise_id, s.set_number, s.reps, s.weight, s.is_warmup, s.is_completed, s.created_at]
+        );
+      }
+    }
+  }
+
+  // Restore body measurements
+  const { data: cloudMeasurements } = await supabase
+    .from("gt_body_measurements")
+    .select("*")
+    .eq("user_id", userId);
+
+  for (const m of cloudMeasurements ?? []) {
+    await db.runAsync(
+      `INSERT OR IGNORE INTO body_measurements (id, weight, notes, measured_at, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+      [m.id, m.weight, m.notes, m.measured_at, m.created_at]
+    );
+  }
+
+  return { workouts: cloudWorkouts.length };
+}

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,3 @@
+
+
+claude mcp add --transport http supabase "https://mcp.supabase.com/mcp?project_ref=bdnlmxepcnhfijmnjfcl"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "expo-router": "~6.0.23",
         "expo-secure-store": "^15.0.8",
         "expo-sharing": "^14.0.8",
-        "expo-sqlite": "^16.0.10",
+        "expo-sqlite": "^16.1.0-canary-20260121-a63c0dd",
         "expo-status-bar": "~3.0.9",
         "nativewind": "^4.2.1",
         "react": "19.1.0",
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.6.tgz",
-      "integrity": "sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+      "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.28.6",
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -366,12 +366,12 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dependencies": {
         "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -391,6 +391,17 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@babel/highlight/node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -404,13 +415,18 @@
         "node": ">=4"
       }
     },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
       }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
@@ -1360,9 +1376,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1538,6 +1554,25 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/@expo/cli/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@expo/cli/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -1555,17 +1590,44 @@
       }
     },
     "node_modules/@expo/cli/node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/@expo/cli/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@expo/cli/node_modules/pretty-format": {
@@ -1580,11 +1642,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/@expo/cli/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/@expo/cli/node_modules/semver": {
       "version": "7.7.4",
@@ -1646,6 +1703,25 @@
         "xml2js": "0.6.0"
       }
     },
+    "node_modules/@expo/config-plugins/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@expo/config-plugins/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -1663,11 +1739,11 @@
       }
     },
     "node_modules/@expo/config-plugins/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1700,6 +1776,25 @@
         "@babel/highlight": "^7.10.4"
       }
     },
+    "node_modules/@expo/config/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@expo/config/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@expo/config/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -1717,11 +1812,11 @@
       }
     },
     "node_modules/@expo/config/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1779,9 +1874,9 @@
       }
     },
     "node_modules/@expo/env": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.0.8.tgz",
-      "integrity": "sha512-5VQD6GT8HIMRaSaB5JFtOXuvfDVU80YtZIuUT/GDhUF782usIXY13Tn3IdDz1Tm/lqA9qnRZQ1BF4t7LlvdJPA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.0.11.tgz",
+      "integrity": "sha512-xV+ps6YCW7XIPVUwFVCRN2nox09dnRwy8uIjwHWTODu0zFw4kp4omnVkl0OOjuu2XOe7tdgAHxikrkJt9xB/7Q==",
       "dependencies": {
         "chalk": "^4.0.0",
         "debug": "^4.3.4",
@@ -1791,9 +1886,9 @@
       }
     },
     "node_modules/@expo/image-utils": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.8.tgz",
-      "integrity": "sha512-HHHaG4J4nKjTtVa1GG9PCh763xlETScfEyNxxOvfTRr8IKPJckjTyqSLEtdJoFNJ1vqiABEjW7tqGhqGibZLeA==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.12.tgz",
+      "integrity": "sha512-3KguH7kyKqq7pNwLb9j6BBdD/bjmNwXZG/HPWT6GWIXbwrvAJt2JNyYTP5agWJ8jbbuys1yuCzmkX+TU6rmI7A==",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
@@ -1801,10 +1896,7 @@
         "jimp-compact": "0.16.1",
         "parse-png": "^2.1.0",
         "resolve-from": "^5.0.0",
-        "resolve-global": "^1.0.0",
-        "semver": "^7.6.0",
-        "temp-dir": "~2.0.0",
-        "unique-string": "~2.0.0"
+        "semver": "^7.6.0"
       }
     },
     "node_modules/@expo/image-utils/node_modules/semver": {
@@ -1819,20 +1911,12 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.8.tgz",
-      "integrity": "sha512-9LOTh1PgKizD1VXfGQ88LtDH0lRwq9lsTb4aichWTWSWqy3Ugfkhfm3BhzBIkJJfQQ5iJu3m/BoRlEIjoCGcnQ==",
+      "version": "10.0.12",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.12.tgz",
+      "integrity": "sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==",
       "dependencies": {
-        "@babel/code-frame": "~7.10.4",
+        "@babel/code-frame": "^7.20.0",
         "json5": "^2.2.3"
-      }
-    },
-    "node_modules/@expo/json-file/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
       }
     },
     "node_modules/@expo/metro": {
@@ -1892,6 +1976,25 @@
         }
       }
     },
+    "node_modules/@expo/metro-config/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@expo/metro-config/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -1909,17 +2012,44 @@
       }
     },
     "node_modules/@expo/metro-config/node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/@expo/metro-config/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@expo/metro-runtime": {
@@ -1969,23 +2099,22 @@
       }
     },
     "node_modules/@expo/osascript": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.3.8.tgz",
-      "integrity": "sha512-/TuOZvSG7Nn0I8c+FcEaoHeBO07yu6vwDgk7rZVvAXoeAK5rkA09jRyjYsZo+0tMEFaToBeywA6pj50Mb3ny9w==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.4.2.tgz",
+      "integrity": "sha512-/XP7PSYF2hzOZzqfjgkoWtllyeTN8dW3aM4P6YgKcmmPikKL5FdoyQhti4eh6RK5a5VrUXJTOlTNIpIHsfB5Iw==",
       "dependencies": {
-        "@expo/spawn-async": "^1.7.2",
-        "exec-async": "^2.2.0"
+        "@expo/spawn-async": "^1.7.2"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@expo/package-manager": {
-      "version": "1.9.10",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.9.10.tgz",
-      "integrity": "sha512-axJm+NOj3jVxep49va/+L3KkF3YW/dkV+RwzqUJedZrv4LeTqOG4rhrCaCPXHTvLqCTDKu6j0Xyd28N7mnxsGA==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.10.3.tgz",
+      "integrity": "sha512-ZuXiK/9fCrIuLjPSe1VYmfp0Sa85kCMwd8QQpgyi5ufppYKRtLBg14QOgUqj8ZMbJTxE0xqzd0XR7kOs3vAK9A==",
       "dependencies": {
-        "@expo/json-file": "^10.0.8",
+        "@expo/json-file": "^10.0.12",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "npm-package-arg": "^11.0.0",
@@ -2076,9 +2205,9 @@
       "integrity": "sha512-nDRbLmSrJar7abvUjp3smDwH8HcbZcoOEa5jVPUv9/9CajgmWw20JNRwTuBRzWIWIkEJDkz20GoNA+tSwUqk0Q=="
     },
     "node_modules/@expo/xcpretty": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.0.tgz",
-      "integrity": "sha512-o2qDlTqJ606h4xR36H2zWTywmZ3v3842K6TU8Ik2n1mfW0S580VHlt3eItVYdLYz+klaPp7CXqanja8eASZjRw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.1.tgz",
+      "integrity": "sha512-KZNxZvnGCtiM2aYYZ6Wz0Ix5r47dAvpNLApFtZWnSoERzAdOMzVBOPysBoM0JlF6FKWZ8GPqgn6qt3dV/8Zlpg==",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
         "chalk": "^4.1.0",
@@ -2257,9 +2386,9 @@
       }
     },
     "node_modules/@jest/diff-sequences": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
-      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
       "dev": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3257,16 +3386,16 @@
       }
     },
     "node_modules/@react-navigation/bottom-tabs": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.10.1.tgz",
-      "integrity": "sha512-MirOzKEe/rRwPSE9HMrS4niIo0LyUhewlvd01TpzQ1ipuXjH2wJbzAM9gS/r62zriB6HMHz2OY6oIRduwQJtTw==",
+      "version": "7.15.9",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.15.9.tgz",
+      "integrity": "sha512-Ou28A1aZLj5wiFQ3F93aIsrI4NCwn3IJzkkjNo9KLFXsc0Yks+UqrVaFlffHFLsrbajuGRG/OQpnMA1ljayY5Q==",
       "dependencies": {
-        "@react-navigation/elements": "^2.9.5",
+        "@react-navigation/elements": "^2.9.14",
         "color": "^4.2.3",
         "sf-symbols-typescript": "^2.1.0"
       },
       "peerDependencies": {
-        "@react-navigation/native": "^7.1.28",
+        "@react-navigation/native": "^7.2.2",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0",
@@ -3274,9 +3403,9 @@
       }
     },
     "node_modules/@react-navigation/core": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.14.0.tgz",
-      "integrity": "sha512-tMpzskBzVp0E7CRNdNtJIdXjk54Kwe/TF9ViXAef+YFM1kSfGv4e/B2ozfXE+YyYgmh4WavTv8fkdJz1CNyu+g==",
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.17.2.tgz",
+      "integrity": "sha512-Rt2OZwcgOmjv401uLGAKaRM6xo0fiBce/A7LfRHI1oe5FV+KooWcgAoZ2XOtgKj6UzVMuQWt3b2e6rxo/mDJRA==",
       "dependencies": {
         "@react-navigation/routers": "^7.5.3",
         "escape-string-regexp": "^4.0.0",
@@ -3291,15 +3420,26 @@
         "react": ">= 18.2.0"
       }
     },
+    "node_modules/@react-navigation/core/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@react-navigation/core/node_modules/react-is": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="
     },
     "node_modules/@react-navigation/elements": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.5.tgz",
-      "integrity": "sha512-iHZU8rRN1014Upz73AqNVXDvSMZDh5/ktQ1CMe21rdgnOY79RWtHHBp9qOS3VtqlUVYGkuX5GEw5mDt4tKdl0g==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.14.tgz",
+      "integrity": "sha512-lKqzu+su2pI/YIZmR7L7xdOs4UL+rVXKJAMpRMBrwInEy96SjIFst6QDGpE89Dunnu3VjVpjWfByo9f2GWBHDQ==",
       "dependencies": {
         "color": "^4.2.3",
         "use-latest-callback": "^0.2.4",
@@ -3307,7 +3447,7 @@
       },
       "peerDependencies": {
         "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.1.28",
+        "@react-navigation/native": "^7.2.2",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0"
@@ -3319,11 +3459,11 @@
       }
     },
     "node_modules/@react-navigation/native": {
-      "version": "7.1.28",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.28.tgz",
-      "integrity": "sha512-d1QDn+KNHfHGt3UIwOZvupvdsDdiHYZBEj7+wL2yDVo3tMezamYy60H9s3EnNVE1Ae1ty0trc7F2OKqo/RmsdQ==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
+      "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
       "dependencies": {
-        "@react-navigation/core": "^7.14.0",
+        "@react-navigation/core": "^7.17.2",
         "escape-string-regexp": "^4.0.0",
         "fast-deep-equal": "^3.1.3",
         "nanoid": "^3.3.11",
@@ -3335,21 +3475,32 @@
       }
     },
     "node_modules/@react-navigation/native-stack": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.11.0.tgz",
-      "integrity": "sha512-yNx9Wr4dfpOHpqjf2sGog4eH6KCYwTAEPlUPrKbvWlQbCRm5bglwPmaTXw9hTovX9v3HIa42yo7bXpbYfq4jzg==",
+      "version": "7.14.10",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.14.10.tgz",
+      "integrity": "sha512-mCbYbYhi7Em2R2nEgwYGdLU38smy+KK+HMMVcwuzllWsF3Qb+jOUEYbB6Or7LvE7SS77BZ6sHdx4HptCEv50hQ==",
       "dependencies": {
-        "@react-navigation/elements": "^2.9.5",
+        "@react-navigation/elements": "^2.9.14",
         "color": "^4.2.3",
         "sf-symbols-typescript": "^2.1.0",
         "warn-once": "^0.1.1"
       },
       "peerDependencies": {
-        "@react-navigation/native": "^7.1.28",
+        "@react-navigation/native": "^7.2.2",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0",
         "react-native-screens": ">= 4.0.0"
+      }
+    },
+    "node_modules/@react-navigation/native/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@react-navigation/routers": {
@@ -3651,9 +3802,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -3728,28 +3879,18 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dependencies": {
-        "color-convert": "^1.9.0"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/ansi-styles/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/ansi-styles/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
@@ -3769,9 +3910,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -3911,12 +4052,12 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.15.tgz",
-      "integrity": "sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+      "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.6",
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -3936,11 +4077,11 @@
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.6.tgz",
-      "integrity": "sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+      "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.6"
+        "@babel/helper-define-polyfill-provider": "^0.6.8"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -4087,9 +4228,9 @@
       ]
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.10.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
+      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
@@ -4146,8 +4287,7 @@
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC"
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
@@ -4169,22 +4309,12 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/brace-expansion/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "engines": {
-        "node": "20 || >=22"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -4199,9 +4329,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4217,11 +4347,11 @@
         }
       ],
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4344,9 +4474,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001770",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
-      "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
+      "version": "1.0.30001784",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
+      "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4375,20 +4505,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/char-regex": {
@@ -4459,6 +4575,17 @@
         "node": ">=12.13.0"
       }
     },
+    "node_modules/chrome-launcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chromium-edge-launcher": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz",
@@ -4470,6 +4597,17 @@
         "lighthouse-logger": "^1.0.0",
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
+      }
+    },
+    "node_modules/chromium-edge-launcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ci-info": {
@@ -4602,12 +4740,11 @@
       }
     },
     "node_modules/comment-json": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.5.1.tgz",
-      "integrity": "sha512-taEtr3ozUmOB7it68Jll7s0Pwm+aoiHyXKrEC8SEodL4rNpdfDLqa7PfBlrgFoCNNdR8ImL+muti5IGvktJAAg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.6.2.tgz",
+      "integrity": "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w==",
       "dependencies": {
         "array-timsort": "^1.0.3",
-        "core-util-is": "^1.0.3",
         "esprima": "^4.0.1"
       },
       "engines": {
@@ -4701,9 +4838,9 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "node_modules/core-js-compat": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
-      "integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
       "dependencies": {
         "browserslist": "^4.28.1"
       },
@@ -4711,11 +4848,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -4759,14 +4891,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/css-in-js-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
@@ -4779,7 +4903,6 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
       "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -4795,7 +4918,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
       "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-      "license": "MIT",
       "dependencies": {
         "mdn-data": "2.0.14",
         "source-map": "^0.6.1"
@@ -4808,7 +4930,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
       "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
       },
@@ -4867,9 +4988,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
-      "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "dev": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -5009,7 +5130,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -5028,14 +5148,12 @@
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ],
-      "license": "BSD-2-Clause"
+      ]
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -5050,7 +5168,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
       "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -5104,9 +5221,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A=="
+      "version": "1.5.330",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.330.tgz",
+      "integrity": "sha512-jFNydB5kFtYUobh4IkWUnXeyDbjf/r9gcUEXe1xcrcUxIGfTdzPXA+ld6zBRbwvgIGVzDll/LTIiDztEtckSnA=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -5137,7 +5254,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -5211,14 +5327,11 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.8.0"
       }
     },
     "node_modules/esprima": {
@@ -5248,11 +5361,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/exec-async": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/exec-async/-/exec-async-2.2.0.tgz",
-      "integrity": "sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw=="
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -5431,19 +5539,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-asset/node_modules/expo-constants": {
-      "version": "18.0.13",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
-      "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
-      "dependencies": {
-        "@expo/config": "~12.0.13",
-        "@expo/env": "~2.0.8"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo-constants": {
       "version": "18.0.13",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
@@ -5520,19 +5615,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-linking/node_modules/expo-constants": {
-      "version": "18.0.13",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
-      "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
-      "dependencies": {
-        "@expo/config": "~12.0.13",
-        "@expo/env": "~2.0.8"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo-modules-core": {
       "version": "3.0.29",
       "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.29.tgz",
@@ -5561,19 +5643,6 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/expo-constants": {
-      "version": "18.0.13",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
-      "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
-      "dependencies": {
-        "@expo/config": "~12.0.13",
-        "@expo/env": "~2.0.8"
-      },
-      "peerDependencies": {
-        "expo": "*",
         "react-native": "*"
       }
     },
@@ -5647,6 +5716,17 @@
         }
       }
     },
+    "node_modules/expo-router/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/expo-router/node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -5683,14 +5763,15 @@
       }
     },
     "node_modules/expo-sqlite": {
-      "version": "16.0.10",
-      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-16.0.10.tgz",
-      "integrity": "sha512-tUOKxE9TpfneRG3eOfbNfhN9236SJ7IiUnP8gCqU7umd9DtgDGB/5PhYVVfl+U7KskgolgNoB9v9OZ9iwXN8Eg==",
+      "version": "16.1.0-canary-20260121-a63c0dd",
+      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-16.1.0-canary-20260121-a63c0dd.tgz",
+      "integrity": "sha512-zIv/r/I8QOe/6xN9QEiEpT5IxI2temdBv2ww6AZ6LOhsm6a22Qziriz64IvvNdVvNfD5D/tUpLxRRTrW10nrnw==",
+      "license": "MIT",
       "dependencies": {
         "await-lock": "^2.2.2"
       },
       "peerDependencies": {
-        "expo": "*",
+        "expo": "55.0.0-canary-20260121-a63c0dd",
         "react": "*",
         "react-native": "*"
       }
@@ -5728,16 +5809,6 @@
         "fingerprint": "bin/cli.js"
       }
     },
-    "node_modules/expo/node_modules/@expo/vector-icons": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.0.3.tgz",
-      "integrity": "sha512-SBUyYKphmlfUBqxSfDdJ3jAdEVSALS2VUPOUyqn48oZmb2TL/O7t7/PQm5v4NQujYEPLPMTLn9KVw6H7twwbTA==",
-      "peerDependencies": {
-        "expo-font": ">=14.0.4",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -5749,46 +5820,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/expo/node_modules/babel-preset-expo": {
-      "version": "54.0.10",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.10.tgz",
-      "integrity": "sha512-wTt7POavLFypLcPW/uC5v8y+mtQKDJiyGLzYCjqr9tx0Qc3vCXcDKk1iCFIj/++Iy5CWhhTflEa7VvVPNWeCfw==",
+    "node_modules/expo/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/expo/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/plugin-proposal-decorators": "^7.12.9",
-        "@babel/plugin-proposal-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-export-default-from": "^7.24.7",
-        "@babel/plugin-transform-class-static-block": "^7.27.1",
-        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
-        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
-        "@babel/plugin-transform-parameters": "^7.24.7",
-        "@babel/plugin-transform-private-methods": "^7.24.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-        "@babel/plugin-transform-runtime": "^7.24.7",
-        "@babel/preset-react": "^7.22.15",
-        "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "0.81.5",
-        "babel-plugin-react-compiler": "^1.0.0",
-        "babel-plugin-react-native-web": "~0.21.0",
-        "babel-plugin-syntax-hermes-parser": "^0.29.1",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "debug": "^4.3.4",
-        "resolve-from": "^5.0.0"
+        "balanced-match": "^4.0.2"
       },
-      "peerDependencies": {
-        "@babel/runtime": "^7.20.0",
-        "expo": "*",
-        "react-refresh": ">=0.14.0 <1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/runtime": {
-          "optional": true
-        },
-        "expo": {
-          "optional": true
-        }
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/expo/node_modules/commander": {
@@ -5797,19 +5845,6 @@
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/expo/node_modules/expo-constants": {
-      "version": "18.0.13",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
-      "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
-      "dependencies": {
-        "@expo/config": "~12.0.13",
-        "@expo/env": "~2.0.8"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo/node_modules/expo-modules-autolinking": {
@@ -5844,17 +5879,44 @@
       }
     },
     "node_modules/expo/node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo/node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/expo/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/expo/node_modules/pretty-format": {
@@ -5869,11 +5931,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/expo/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/expo/node_modules/semver": {
       "version": "7.7.4",
@@ -6212,7 +6269,6 @@
       "version": "0.1.80",
       "resolved": "https://registry.npmjs.org/gifted-charts-core/-/gifted-charts-core-0.1.80.tgz",
       "integrity": "sha512-sAHsi25+S8xe7gReodbmtj85AKMasGRGZ2fNNr+zLo7ioB8ovSbpsmGd8cS1B0VJ+JDlgIVVyoRx39RGawVwAQ==",
-      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*",
@@ -6248,37 +6304,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
-      "dependencies": {
-        "ini": "^1.3.4"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/gopd": {
@@ -7065,15 +7090,15 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
-      "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/diff-sequences": "30.0.1",
+        "@jest/diff-sequences": "30.3.0",
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "pretty-format": "30.2.0"
+        "pretty-format": "30.3.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -7221,15 +7246,15 @@
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
-      "integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
       "dev": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.2.0",
-        "pretty-format": "30.2.0"
+        "jest-diff": "30.3.0",
+        "pretty-format": "30.3.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -7540,9 +7565,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -7600,11 +7625,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/jest-validate/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/jest-watcher": {
       "version": "29.7.0",
@@ -7795,9 +7815,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/lightningcss": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
-      "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -7809,23 +7829,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.31.1",
-        "lightningcss-darwin-arm64": "1.31.1",
-        "lightningcss-darwin-x64": "1.31.1",
-        "lightningcss-freebsd-x64": "1.31.1",
-        "lightningcss-linux-arm-gnueabihf": "1.31.1",
-        "lightningcss-linux-arm64-gnu": "1.31.1",
-        "lightningcss-linux-arm64-musl": "1.31.1",
-        "lightningcss-linux-x64-gnu": "1.31.1",
-        "lightningcss-linux-x64-musl": "1.31.1",
-        "lightningcss-win32-arm64-msvc": "1.31.1",
-        "lightningcss-win32-x64-msvc": "1.31.1"
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz",
-      "integrity": "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
       ],
@@ -7842,9 +7862,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz",
-      "integrity": "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
@@ -7861,9 +7881,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz",
-      "integrity": "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
@@ -7880,9 +7900,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz",
-      "integrity": "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
@@ -7899,9 +7919,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz",
-      "integrity": "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
@@ -7918,9 +7938,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz",
-      "integrity": "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
@@ -7937,9 +7957,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz",
-      "integrity": "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
       ],
@@ -7956,9 +7976,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz",
-      "integrity": "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
       ],
@@ -7975,9 +7995,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz",
-      "integrity": "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
       ],
@@ -7994,9 +8014,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz",
-      "integrity": "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
@@ -8013,9 +8033,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz",
-      "integrity": "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
@@ -8079,6 +8099,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/log-symbols/node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -8092,13 +8123,18 @@
         "node": ">=4"
       }
     },
-    "node_modules/log-symbols/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
+    "node_modules/log-symbols/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
       }
+    },
+    "node_modules/log-symbols/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/log-symbols/node_modules/has-flag": {
       "version": "3.0.0",
@@ -8189,8 +8225,7 @@
     "node_modules/mdn-data": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "license": "CC0-1.0"
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -8564,9 +8599,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -8623,25 +8658,14 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
+        "node": "*"
       }
     },
     "node_modules/minimist": {
@@ -8769,9 +8793,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -8782,9 +8806,9 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -8835,7 +8859,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -8998,6 +9021,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ora/node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -9011,13 +9045,18 @@
         "node": ">=4"
       }
     },
-    "node_modules/ora/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
+    "node_modules/ora/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
       }
+    },
+    "node_modules/ora/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/ora/node_modules/has-flag": {
       "version": "3.0.0",
@@ -9178,9 +9217,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "engines": {
         "node": "20 || >=22"
       }
@@ -9191,9 +9230,9 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
-      "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.2.tgz",
+      "integrity": "sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==",
       "engines": {
         "node": ">=10"
       },
@@ -9419,9 +9458,9 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "30.0.5",
@@ -9445,9 +9484,9 @@
       }
     },
     "node_modules/pretty-format/node_modules/@sinclair/typebox": {
-      "version": "0.34.48",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
-      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "dev": true
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
@@ -9461,12 +9500,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true
     },
     "node_modules/proc-log": {
       "version": "4.2.0",
@@ -10022,7 +10055,6 @@
       "version": "1.4.76",
       "resolved": "https://registry.npmjs.org/react-native-gifted-charts/-/react-native-gifted-charts-1.4.76.tgz",
       "integrity": "sha512-GmaICcCouL7Z13KRfeVT6ngfQ2cByrVQ7TzWY8SPNUyQf+6/dZZ2+ySChNTsaFFhuwW2eTFBrDSz6HXBIzd0PA==",
-      "license": "MIT",
       "dependencies": {
         "gifted-charts-core": "0.1.80"
       },
@@ -10043,9 +10075,9 @@
       }
     },
     "node_modules/react-native-is-edge-to-edge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
-      "integrity": "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.3.1.tgz",
+      "integrity": "sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -10055,7 +10087,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/react-native-linear-gradient/-/react-native-linear-gradient-2.8.3.tgz",
       "integrity": "sha512-KflAXZcEg54PXkLyflaSZQ3PJp4uC4whM7nT/Uot9m0e/qxFV3p6uor1983D1YOBJbJN7rrWdqIjq0T42jOJyA==",
-      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -10114,7 +10145,6 @@
       "version": "15.12.1",
       "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
       "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
-      "license": "MIT",
       "dependencies": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3",
@@ -10232,9 +10262,9 @@
       }
     },
     "node_modules/react-native/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -10344,9 +10374,9 @@
       }
     },
     "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -10496,17 +10526,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-global": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
-      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
-      "dependencies": {
-        "global-dirs": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/resolve-workspace-root": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/resolve-workspace-root/-/resolve-workspace-root-2.0.1.tgz",
@@ -10633,9 +10652,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "engines": {
         "node": ">=11.0.0"
       }
@@ -10873,9 +10892,9 @@
       }
     },
     "node_modules/slugify": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.8.tgz",
+      "integrity": "sha512-HVk9X1E0gz3mSpoi60h/saazLKXKaZThMLU3u/aNwoYn8/xQyX2MGxL0ui2eaokkD7tF+Zo+cKTHUbe1mmmGzA==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -11166,9 +11185,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -11188,14 +11207,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/temp-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -11212,9 +11223,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
+      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -11244,26 +11255,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/thenify": {
@@ -11306,9 +11297,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "engines": {
         "node": ">=12"
       },
@@ -11413,9 +11404,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "engines": {
         "node": ">=18.17"
       }
@@ -11459,17 +11450,6 @@
       "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-      "dependencies": {
-        "crypto-random-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/unpipe": {
@@ -11668,9 +11648,12 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
@@ -11699,13 +11682,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/whatwg-url-without-unicode/node_modules/webidl-conversions": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/whatwg-url/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -11742,9 +11722,9 @@
       }
     },
     "node_modules/wonka": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.5.tgz",
-      "integrity": "sha512-SSil+ecw6B4/Dm7Pf2sAshKQ5hWFvfyGlfPbEd6A14dOH6VDjrmbY86u6nZvy9omGwwIPFR8V41+of1EezgoUw=="
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.6.tgz",
+      "integrity": "sha512-MXH+6mDHAZ2GuMpgKS055FR6v0xVP3XwquxIMYXgiW+FejHQlMGlvVRZT4qMCxR+bEo/FCtIdKxwej9WV3YQag=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -11760,20 +11740,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/wrappy": {
@@ -11794,9 +11760,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -11867,9 +11833,9 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "expo-router": "~6.0.23",
     "expo-secure-store": "^15.0.8",
     "expo-sharing": "^14.0.8",
-    "expo-sqlite": "^16.0.10",
+    "expo-sqlite": "^16.1.0-canary-20260121-a63c0dd",
     "expo-status-bar": "~3.0.9",
     "nativewind": "^4.2.1",
     "react": "19.1.0",

--- a/stores/auth-store.ts
+++ b/stores/auth-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { supabase } from "@/lib/supabase";
 import type { User } from "@/types";
 
 interface AuthState {
@@ -8,7 +9,9 @@ interface AuthState {
 
   setUser: (user: User | null) => void;
   setLoading: (loading: boolean) => void;
-  signOut: () => void;
+  signIn: (email: string, password: string) => Promise<string | null>;
+  signUp: (email: string, password: string) => Promise<string | null>;
+  signOut: () => Promise<void>;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
@@ -16,19 +19,21 @@ export const useAuthStore = create<AuthState>((set) => ({
   isAuthenticated: false,
   isLoading: true,
 
-  setUser: (user) =>
-    set({
-      user,
-      isAuthenticated: !!user,
-      isLoading: false,
-    }),
-
+  setUser: (user) => set({ user, isAuthenticated: !!user, isLoading: false }),
   setLoading: (isLoading) => set({ isLoading }),
 
-  signOut: () =>
-    set({
-      user: null,
-      isAuthenticated: false,
-      isLoading: false,
-    }),
+  signIn: async (email, password) => {
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    return error?.message ?? null;
+  },
+
+  signUp: async (email, password) => {
+    const { error } = await supabase.auth.signUp({ email, password });
+    return error?.message ?? null;
+  },
+
+  signOut: async () => {
+    await supabase.auth.signOut();
+    set({ user: null, isAuthenticated: false, isLoading: false });
+  },
 }));

--- a/stores/settings-store.ts
+++ b/stores/settings-store.ts
@@ -7,6 +7,7 @@ interface SettingsState extends UserSettings {
   setUnitPreference: (unit: WeightUnit) => void;
   setThemePreference: (theme: ThemePreference) => void;
   setRestTimerDefault: (seconds: number) => void;
+  setDisplayName: (name: string) => void;
   reset: () => void;
 }
 
@@ -14,6 +15,7 @@ const defaultSettings: UserSettings = {
   unitPreference: "kg",
   themePreference: "system",
   restTimerDefault: 90,
+  displayName: "",
 };
 
 export const useSettingsStore = create<SettingsState>()(
@@ -23,6 +25,7 @@ export const useSettingsStore = create<SettingsState>()(
       setUnitPreference: (unit) => set({ unitPreference: unit }),
       setThemePreference: (theme) => set({ themePreference: theme }),
       setRestTimerDefault: (seconds) => set({ restTimerDefault: seconds }),
+      setDisplayName: (name) => set({ displayName: name }),
       reset: () => set(defaultSettings),
     }),
     {

--- a/stores/workout-store.ts
+++ b/stores/workout-store.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
 import * as db from "@/lib/db";
+import { syncWorkoutToCloud } from "@/lib/sync";
+import { useAuthStore } from "@/stores/auth-store";
 import type {
   Workout,
   WorkoutExercise,
@@ -125,7 +127,14 @@ export const useWorkoutStore = create<WorkoutState>((set, get) => ({
     set({ isLoading: true });
     try {
       await db.completeWorkout(active.workout.id, notes);
+      const workoutId = active.workout.id;
       set({ active: null, isLoading: false, restTimerEndTime: null });
+
+      // Fire-and-forget auto-sync
+      const userId = useAuthStore.getState().user?.id;
+      if (userId) {
+        syncWorkoutToCloud(workoutId, userId).catch(() => {});
+      }
     } catch (error) {
       console.error("Failed to complete workout:", error);
       set({ isLoading: false });

--- a/types/index.ts
+++ b/types/index.ts
@@ -104,6 +104,7 @@ export interface UserSettings {
   unitPreference: WeightUnit;
   themePreference: ThemePreference;
   restTimerDefault: number; // in seconds
+  displayName: string;
 }
 
 // Auth Types


### PR DESCRIPTION
## Summary

- Email/password sign in + sign up with session persistence via SecureStore
- Auto-sync to Supabase after each completed workout (fire-and-forget)
- Manual back up + restore from cloud on profile screen
- 5 Supabase tables (`gt_workouts`, `gt_workout_exercises`, `gt_workout_sets`, `gt_personal_records`, `gt_body_measurements`) with RLS
- Share workout as formatted text via native share sheet (from history action sheet)
- Profile: editable display name, working dark mode toggle, body weight log, lifetime stats card
- Fix `react-native-url-polyfill` import for React Native 0.81
- Bump version to 4.0.6

## Test plan

- [ ] Sign up with email → check email confirmation
- [ ] Sign in → profile shows email, backup/restore buttons visible
- [ ] Complete a workout → row appears in Supabase `gt_workouts`
- [ ] Tap "Back up now" → all workouts appear in Supabase dashboard
- [ ] Tap "Restore from cloud" → confirm alert shown, data merged
- [ ] Long-press workout in history → Share option opens native share sheet
- [ ] Dark mode toggle persists after app restart
- [ ] Sign out → profile shows sign in CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)